### PR TITLE
Misc fixes

### DIFF
--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -529,6 +529,7 @@ function importCSV(event) {
                         }
 
                         parseDecklist();
+                        let warnings = validateInput();
 
                         if (firstDeck) {
                             if ($("select[name=eventformat]").val() == "Highlander") {
@@ -544,7 +545,7 @@ function importCSV(event) {
                         if ($("select[name=eventformat]").val() == "Highlander") {
                             addHLTemplateToDL(dl);
                             addHLMetadataToDL(dl);
-                            addHLCardsToDL(dl);
+                            addHLCardsToDL(dl, warnings);
                         } else {
                             addTemplateToDL(dl);
                             addMetaDataToDL(dl);

--- a/js/decklist/main.js
+++ b/js/decklist/main.js
@@ -665,24 +665,24 @@ function addHLCardsToDL(dl, val) {
                 });
                 if(cardname.length >= 35) {
                     if (truncateDFCs) {
-                        dl.text(cardname.substring(0, 30) + "...", x + 38, y)
+                        dl.text(cardname.substring(0, 30) + "...", x + 33, y)
                     } else {
                         var both_halves = cardname.split(' // ');
                         if (both_halves.length == 2){
                             // Would spill to next column?
                             if (((i+1) == (21 + (numPages * 60))) || ((i+1) == (42 + (numPages * 60)))) {
-                                 dl.text(cardname.substring(0, 30) + "...", x + 38, y)
+                                 dl.text(cardname.substring(0, 30) + "...", x + 33, y)
                             } else {
-                                dl.text(both_halves[0] + ' // ', x + 38, y);
+                                dl.text(both_halves[0] + ' // ', x + 33, y);
                                 y = y + 20;
                                 i++;
-                                dl.text(both_halves[1], x + 42, y);
+                                dl.text(both_halves[1], x + 37, y);
                             }
                             loopEnd++;
                         }
                     }
                 } else {
-                    dl.text(cardname, x + 38, y);
+                    dl.text(cardname, x + 33, y);
                 }
 
             }

--- a/js/decklist/main.js
+++ b/js/decklist/main.js
@@ -345,8 +345,8 @@ function addHLTemplateToDL(dl) {
     }
 
 
-    dl.rect(684, 444, 86, 19); // Box for main deck total
-    dl.rect(684, 464, 86, 19); // Box for side board total
+    dl.rect(683, 443, 87, 20); // Box for main deck total
+    dl.rect(683, 463, 87, 20); // Box for side board total
 
     // Shaded rectangles
     dl.setLineWidth(1);


### PR DESCRIPTION
- Fixed the 7PH total boxes (mainboard and sideboard) being one pixel out of alignment
- Moved the 7PH card names 5 pixels to the left to remove excess whitespace
- Fixed warnings (e.g. E=1) not being shown when importing by Melee CSV